### PR TITLE
Bump up Freemarker version (for filter feature)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
         <dependency>
             <groupId>org.freemarker</groupId>
             <artifactId>freemarker</artifactId>
-            <version>2.3.28</version>
+            <version>2.3.29</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/junit/junit -->
         <dependency>


### PR DESCRIPTION
Filter feature was only added in 2.3.29. 

See [here](https://freemarker.apache.org/docs/ref_builtins_sequence.html#ref_builtin_filter)