### PR TITLE
added warn log when table has no proc defined

### DIFF
--- a/src/main/java/bbd/jportal2/generators/FreeMarker/FreeMarker.java
+++ b/src/main/java/bbd/jportal2/generators/FreeMarker/FreeMarker.java
@@ -166,6 +166,12 @@ public class FreeMarker extends BaseGenerator implements ITemplateBasedSIProcess
         String strRelativePath = templateRelativePath.toString();
 
         HashSet<String> doneFiles = new HashSet<>();
+
+        if (database.tables.get(0).procs.isEmpty()) {
+            logger.warn("\t [{}]: Table: [{}] Has no procs defined. Skipping...", generatorName, database.tables.get(0).name);
+            return;
+        }
+
         for (Proc proc : database.tables.get(0).procs)
         {
             root.put("proc", proc);


### PR DESCRIPTION
If a table has no procs defined, Jportal2 freemarker does not generate anything but does not tell the user why nothing was generated, This PR is just to add a message to notify that 1 proc needs to be present.

We might consider making at least 1 proc mandatory?