### PR TITLE
Nullable Field check on Bulk Operation

### DIFF
--- a/src/main/java/bbd/jportal2/generators/JavaJCCode.java
+++ b/src/main/java/bbd/jportal2/generators/JavaJCCode.java
@@ -579,11 +579,15 @@ public class JavaJCCode extends BaseGenerator implements IBuiltInSIProcessor {
             Field field = pair.field;
 
             if (field.isNull) {
-                outData.println("    if(" + field.useLowerName() + " == null) {");
-                outData.print("        prep.setNull(");
+                if (proc.isMultipleInput) {
+                    outData.println(extraTab + extraTab  +"    if (record." + field.useLowerName() + " == null) {");
+                } else {
+                    outData.println("    if (" + field.useLowerName() + " == null) {");
+                }
+                outData.print(extraTab + extraTab  +"        prep.setNull(");
                 outData.print(i + 1);
                 outData.println(", java.sql.Types.NULL);");
-                outData.println("    } else {");
+                outData.println(extraTab + extraTab  +"    } else {");
                 outData.print("    ");
             }
 
@@ -609,7 +613,7 @@ public class JavaJCCode extends BaseGenerator implements IBuiltInSIProcessor {
                     String.format(enumToInt, field.useLowerName())));
 
             if (field.isNull) {
-                outData.println("    };");
+                outData.println(extraTab + extraTab  +"    };");
             }
 
         }


### PR DESCRIPTION
Bulk Operation code gen now validates record param field  instead of class field  
![before](https://user-images.githubusercontent.com/839895/97173009-8f34c480-1798-11eb-835f-b0eeb5d39006.png)
![after](https://user-images.githubusercontent.com/839895/97173010-9065f180-1798-11eb-8415-485ba0c7223b.png)
