### PR TITLE
Added bigsequence support for oracle DDLs

### DIFF
--- a/src/main/java/bbd/jportal2/generators/OracleDDL.java
+++ b/src/main/java/bbd/jportal2/generators/OracleDDL.java
@@ -91,6 +91,7 @@ public class OracleDDL extends BaseGenerator implements IBuiltInSIProcessor {
         int i;
         Field field;
         int j;
+        boolean tableHasBigSequence = false;
 
         if (!table.fields.isEmpty()) {
             outData.println("DROP TABLE " + tableOwner + table.name + " CASCADE CONSTRAINTS;");
@@ -108,6 +109,10 @@ public class OracleDDL extends BaseGenerator implements IBuiltInSIProcessor {
                     hasNotNull = true;
                 } else if (!field.isNull) {
                     hasNotNull = true;
+                }
+
+                if (field.type == Field.BIGSEQUENCE) {
+                    tableHasBigSequence = true;
                 }
 
             }
@@ -138,7 +143,12 @@ public class OracleDDL extends BaseGenerator implements IBuiltInSIProcessor {
                 outData.println();
                 outData.println("CREATE SEQUENCE " + tableOwner + table.name + "Seq");
                 outData.println("  MINVALUE 1");
-                outData.println("  MAXVALUE 999999999");
+                if (tableHasBigSequence) {
+                    //18 nines for a big sequence following the example of 9 nines for a regular sequence
+                    outData.println("  MAXVALUE 999999999999999999");
+                } else {
+                    outData.println("  MAXVALUE 999999999");
+                }
                 outData.println("  CYCLE");
                 outData.println("  ORDER;");
                 outData.println();
@@ -470,6 +480,8 @@ public class OracleDDL extends BaseGenerator implements IBuiltInSIProcessor {
             case 2:
             case 8:
             case 16:
+            case 24:
+                return "NUMBER(19)";
             default:
                 return "unknown";
         }


### PR DESCRIPTION
Added BIGSEQUENCE support for oracle DB. I followed the same standard as for the regular sequences, just with a larger value.