### PR TITLE
Feat/sync

### DIFF
--- a/src/main/java/bbd/jportal2/generators/Db2DDL.java
+++ b/src/main/java/bbd/jportal2/generators/Db2DDL.java
@@ -51,16 +51,24 @@ public class Db2DDL extends BaseGenerator implements IBuiltInSIProcessor {
             hasData = false;
 
             try (PrintWriter outData = this.openOutputFileForGeneration("sql", output + fileName + ".sql")) {
-                for (int i = 0; i < database.tables.size(); i++)
-                    generate((Table) database.tables.elementAt(i), outData);
+                for (int i = 0; i < database.tables.size(); i++) {
+                    Table table = database.tables.elementAt(i);
+                    if (table.name.equals(database.output)) {
+                        generate(table, outData);
+                    }
+                }
                 outData.flush();
             }
             if (hasData == true) {
 
 
                 try (PrintWriter outData = this.openOutputFileForGeneration("_data.sql", output + fileName + "_data_.sql")) {
-                    for (int i = 0; i < database.tables.size(); i++)
-                        generateData((Table) database.tables.elementAt(i), outData);
+                    for (int i = 0; i < database.tables.size(); i++) {
+                        Table table = database.tables.elementAt(i);
+                        if (table.name.equals(database.output)) {
+                            generateData(table, outData);
+                        }
+                    }
                     outData.flush();
                 }
             }

--- a/src/main/java/bbd/jportal2/generators/MSSqlDDL.java
+++ b/src/main/java/bbd/jportal2/generators/MSSqlDDL.java
@@ -152,10 +152,18 @@ public class MSSqlDDL extends BaseGenerator implements IBuiltInSIProcessor
       try (PrintWriter outputFile = this.openOutputFileForGeneration("sql", output + fileName + ".sql")) {
           outputFile.println("USE " + database.name);
           outputFile.println();
-          for (int i = 0; i < database.tables.size(); i++)
-              generateTable((Table) database.tables.elementAt(i), outputFile);
-          for (int i = 0; i < database.views.size(); i++)
-              generateView((View) database.views.elementAt(i), outputFile, "");
+          for (int i = 0; i < database.tables.size(); i++) {
+            Table table = database.tables.elementAt(i);
+            if (table.name.equals(database.output)) {
+              generateTable(table, outputFile);
+            }
+          }
+          for (int i = 0; i < database.views.size(); i++) {
+            View view = database.views.elementAt(i);
+            if (view.name.equals(database.output)) {
+              generateView(view, outputFile, "");
+            }
+          }
           outputFile.flush();
       }
     }

--- a/src/main/java/bbd/jportal2/generators/OracleDDL.java
+++ b/src/main/java/bbd/jportal2/generators/OracleDDL.java
@@ -55,15 +55,24 @@ public class OracleDDL extends BaseGenerator implements IBuiltInSIProcessor {
 
                 int i;
                 for (i = 0; i < database.tables.size(); ++i) {
-                    generate(database.tables.elementAt(i), outData);
+                    Table table = database.tables.elementAt(i);
+                    if (table.name.equals(database.output)) {
+                        generate(database.tables.elementAt(i), outData);
+                    }
                 }
 
                 for (i = 0; i < database.views.size(); ++i) {
-                    generate(database.views.elementAt(i), outData, "", tableOwner);
+                    View view = database.views.elementAt(i);
+                    if (view.name.equals(database.output)) {
+                        generate(database.views.elementAt(i), outData, "", tableOwner);
+                    }
                 }
 
                 for (i = 0; i < database.sequences.size(); ++i) {
-                    generate(database.sequences.elementAt(i), outData, tableOwner);
+                    Sequence sequence = database.sequences.elementAt(i);
+                    if (sequence.name.equals(database.output)) {
+                        generate(database.sequences.elementAt(i), outData, tableOwner);
+                    }
                 }
 
                 outData.flush();

--- a/src/main/java/bbd/jportal2/generators/PostgresDDL.java
+++ b/src/main/java/bbd/jportal2/generators/PostgresDDL.java
@@ -39,8 +39,12 @@ public class PostgresDDL extends BaseGenerator implements IBuiltInSIProcessor {
         logger.info("DDL: {}", fileName);
 
         try (PrintWriter outData = openOutputFileForGeneration("sql", fileName)) {
-            for (int i = 0; i < database.tables.size(); i++)
-                generateTable(database, database.tables.elementAt(i), outData);
+            for (int i = 0; i < database.tables.size(); i++) {
+                Table table = database.tables.elementAt(i);
+                if (table.name.equals(database.output)) {
+                    generateTable(database, table, outData);
+                }
+            }
             outData.flush();
         } catch (IOException e1) {
             logger.error("Generate PosgreSQL IO Error", e1);

--- a/src/main/javacc/JPortal.jj
+++ b/src/main/javacc/JPortal.jj
@@ -125,7 +125,7 @@ public class JPortal
       }
       else
         JPortal.ReInit(reader);
-      database = null;
+      // database = null;
       table = null;
       entry = null;
       field = null;
@@ -609,7 +609,7 @@ void jInput() :
 {
   <DATABASE> s = jIdent()
   {
-    database = new Database();
+    // database = new Database();
     database.name = s;
     database.userid = "";
     database.password = "";


### PR DESCRIPTION
We needed to comment out the two lines in jportal.jj again so that the __init__.py for SQLAlchemy DAL generation generates correctly. However, this meant that the DDL generation broke again. This pull request adds a check to the DDL generation so that it doesn't generate all the table creates in all the files, but instead only the appropriate creates in the correct files.

Unfortunately the check involves looping through all of the tables in the database and checking each one to determine if we are allowed to generate it. This was the best solution that I could find, it seems like the only other way to search through a vector in Java is to use the collection's binary search. I tried to use it but I haven't been able to figure out how to make it work, so I decided to move on and use this method instead, due to time constraints on getting these fixes in.