### PR TITLE
Add support for strings larger than 2000 characters in oracle.

### DIFF
--- a/src/main/java/bbd/jportal2/generators/OracleDDL.java
+++ b/src/main/java/bbd/jportal2/generators/OracleDDL.java
@@ -430,7 +430,11 @@ public class OracleDDL extends BaseGenerator implements IBuiltInSIProcessor {
             case 3:
                 return "NUMBER(3)";
             case 4:
-                return "VARCHAR2(" + field.length + ")";
+                if (field.length > 2000) {
+                    return "NCLOB";
+                } else {
+                    return "VARCHAR2(" + field.length + ")";
+                }
             case 5:
                 return "DATE";
             case 6:


### PR DESCRIPTION
Oracle's varchar2 type only supports a maximum of 2000 characters, so to accomodate char(5000) data types that can be used in the si files, I've updated the oracle generation to switch to using an NCLOB when the field length exceeds 2000.